### PR TITLE
remove check for existence of cmdargs

### DIFF
--- a/rteval-cmd
+++ b/rteval-cmd
@@ -157,9 +157,6 @@ def parse_options(cfg, parser, cmdargs):
                       action='store_true', default=False,
                       help='print rteval version and exit')
 
-    if not cmdargs:
-        cmdargs = ["--help"]
-
     (cmd_opts, cmd_args) = parser.parse_args(args = cmdargs)
     if cmd_opts.rteval___version:
         print("rteval version %s" % RTEVAL_VERSION)


### PR DESCRIPTION
The documentation does not explicitly state that an argument is required to run the script, and in fact all relevant flags have functional defaults. However, the `if not cmdargs` check enforces that at least one flag must be passed to the command.

The behavior should either be as per this PR to simply remove the cmdargs check, or otherwise the documentation and defaults should be updated to require an argument or flag.